### PR TITLE
#1 Modify TE002.002 of 'Binding waardelijst'

### DIFF
--- a/docs/terminologie/binding-waardelijst.md
+++ b/docs/terminologie/binding-waardelijst.md
@@ -1,4 +1,4 @@
-﻿# Binding waardelijst - dit is een test
+﻿# Binding waardelijst
 
 Waardelijsten worden op verschillende manieren aan een zib-element gekoppeld of 'gebonden'. Als de binding van een
 waardelijst 'required' is, mogen uitsluitend waarden uit de gedefinieerde waardelijst worden gebruikt. Als de waarde

--- a/docs/terminologie/binding-waardelijst.md
+++ b/docs/terminologie/binding-waardelijst.md
@@ -18,7 +18,7 @@ voorkeuswaarden worden gezien.
 |----------------------|-----------|
 | Zib-ontwerper        | SHOULD    |
 
-## TE002.002: ALS aanvullende termen onmiskenbaar in geen enkele zorg- of gezondheidscontext toepasbaar zijn, DAN: MAG de binding van een waardelijst 'required' zijn
+## TE001.002: ALS aanvullende termen onmiskenbaar in geen enkele zorg- of gezondheidscontext toepasbaar zijn, DAN: MAG de binding van een waardelijst 'required' zijn
 
 Soms is absoluut zeker dat een vaste set van waarden in alle gevallen volstaat (usecase-onafhankelijk). Alleen in die
 gevallen mag de waardelijst-binding 'required' worden gebruikt.


### PR DESCRIPTION
See issue #1 for background information.

## What?

Fix naming issue in guideline [TE002.002](https://richtlijnen.zib-transitie.nl/terminologie/binding-waardelijst/#te002002-als-aanvullende-termen-onmiskenbaar-in-geen-enkele-zorg-of-gezondheidscontext-toepasbaar-zijn-dan-mag-de-binding-van-een-waardelijst-required-zijn).

## Why?

Wrong guideline code was used.

## How?

Change code [TE002.002](https://richtlijnen.zib-transitie.nl/terminologie/binding-waardelijst/#te002002-als-aanvullende-termen-onmiskenbaar-in-geen-enkele-zorg-of-gezondheidscontext-toepasbaar-zijn-dan-mag-de-binding-van-een-waardelijst-required-zijn) to TE001.002.